### PR TITLE
Skill - Accost

### DIFF
--- a/Contants/Texts/Source/texts/Skills_BattleOrder.txt
+++ b/Contants/Texts/Source/texts/Skills_BattleOrder.txt
@@ -114,6 +114,6 @@ When unit is defender while[NL]
 their HP is 100%, attack first.[X]
 
 ## MSG_SKILL_Accost
-Accost:[NL]
-Continue the current fight[NL]
-until a unit dies.[X]
+Accost: Engage in up to 20[NL]
+rounds of combat. Conditions:[NL]
+(unitSPD + unitHP/2 ) - enemySPD.[X]

--- a/Contants/Texts/Source/texts/Skills_BattleOrder.txt
+++ b/Contants/Texts/Source/texts/Skills_BattleOrder.txt
@@ -112,3 +112,8 @@ enemy, this unit doubles.[X]
 Gale Wings:[NL]
 When unit is defender while[NL]
 their HP is 100%, attack first.[X]
+
+## MSG_SKILL_Accost
+Accost:[NL]
+Continue the current fight[NL]
+until a unit dies.[X]

--- a/Data/SkillSys/SkillExtraInfo.c
+++ b/Data/SkillSys/SkillExtraInfo.c
@@ -283,6 +283,7 @@ const struct SkillExtraInfo gSkillExtraInfo[MAX_SKILL_NUM + 1] = {
     [SID_FranticSwing] = {{ 50 }},
     [SID_CriticalOverload] = {{ 3 }},
     [SID_VigorDance] = {{ 2, 2}},
+    [SID_Accost] = {{ 20 }},
 
 #if (defined(SID_SealDefense) && COMMON_SKILL_VALID(SID_SealDefense))
     [SID_SealDefense] = {{ 6 }},

--- a/Data/SkillSys/SkillInfo.c
+++ b/Data/SkillSys/SkillInfo.c
@@ -3667,4 +3667,10 @@ const struct SkillInfo gSkillInfos[MAX_SKILL_NUM + 1] = {
     },
 #endif
 
+#if (defined(SID_Accost) && COMMON_SKILL_VALID(SID_Accost))
+    [SID_Accost] = {
+        .desc = MSG_SKILL_Accost,
+        .icon = GFX_SkillIcon_WIP,
+    },
+#endif
 };

--- a/Data/SkillSys/SkillTable-generic.c
+++ b/Data/SkillSys/SkillTable-generic.c
@@ -7,7 +7,7 @@ const struct SkillPreloadPConf gSkillPreloadPData[0x100] = {
         .skills = {
             [0] = SID_SpdBonus,
             [1] = SID_PosReturn,
-            [2] = SID_DoubleLion,
+            [2] = SID_HpBonus,
             [3] = SID_Desperation,
         },
     },

--- a/Data/SkillSys/SkillTable-person.c
+++ b/Data/SkillSys/SkillTable-person.c
@@ -4,7 +4,7 @@
 
 const u16 gConstSkillTable_Person[0x100][2] = {
     [CHARACTER_EIRIKA] = {
-        SID_Supply,
+        SID_Accost,
         SID_InitSpectrum,
     },
 

--- a/Wizardry/Core/BattleSys/Source/BattleOrder.c
+++ b/Wizardry/Core/BattleSys/Source/BattleOrder.c
@@ -287,7 +287,7 @@ STATIC_DECLAR bool ContinueIfAccost(struct BattleUnit *attacker, struct BattleUn
 {
     int activationChance = 0;
 
-    if (BattleSkillTester(attacker, SID_Accost))
+    if (attacker->unit.curHP >= 25 && (attacker, SID_Accost))
         activationChance = (attacker->battleSpeed + attacker->unit.curHP / 2) - defender->battleSpeed;
 
     else if (defender->unit.curHP >= 25 && BattleSkillTester(defender, SID_Accost))

--- a/include/constants/skills-others.enum.txt
+++ b/include/constants/skills-others.enum.txt
@@ -135,6 +135,7 @@ SID_Mimic
 SID_Insomnia
 SID_Comatose
 SID_MagicBounce
+SID_Accost
 
 // Shop skills
 SID_Deal


### PR DESCRIPTION
So this is the FE4 implementation of Accost that can go up to 20 rounds given the following calcuation:

- (attack speed + attack HP / 2) - defender speed.

I have some concerns regaring performance for something that can potentially go on so long, but I'm guessing it will be more of a concern when I get to its big brother with a 100% activation rate.