### PR TITLE
Skill-LullSkills

### DIFF
--- a/Contants/Texts/Source/texts/Skills_BattleStatus.txt
+++ b/Contants/Texts/Source/texts/Skills_BattleStatus.txt
@@ -747,72 +747,72 @@ Lull-Def[X]
 
 ## MSG_SKILL_LullDefense
 Lull Defense:[NL]
-Negated the effects of DEF[NL]
-boosting rally skills on the enemy.[X]
+Negates the application of
+DEF rallies in a 3 tile range.[X]
 
 ## MSG_SKILL_LullLuck_NAME
 Lull-Lck[X]
 
 ## MSG_SKILL_LullLuck
 Lull Luck:[NL]
-Negated the effects of LCK[NL]
-boosting rally skills on the enemy.[X]
+Negates the application of
+LCK rallies in a 3 tile range.[X]
 
 ## MSG_SKILL_LullMagic_NAME
 Lull-Mag[X]
 
 ## MSG_SKILL_LullMagic
 Lull Magic:[NL]
-Negated the effects of MAG[NL]
-boosting rally skills on the enemy.[X]
+Negates the application of
+MAG rallies in a 3 tile range.[X]
 
 ## MSG_SKILL_LullMovement_NAME
 Lull-Mov[X]
 
 ## MSG_SKILL_LullMovement
 Lull Movement:[NL]
-Negated the effects of MOV[NL]
-boosting rally skills on the enemy.[X]
+Negates the application of
+MOV rallies in a 3 tile range.[X]
 
 ## MSG_SKILL_LullResistance_NAME
 Lull-Res[X]
 
 ## MSG_SKILL_LullResistance
 Lull Resistance:[NL]
-Negated the effects of RES[NL]
-boosting rally skills on the enemy.[X]
+Negates the application of
+RES rallies in a 3 tile range.[X]
 
 ## MSG_SKILL_LullSkill_NAME
 Lull-Skl[X]
 
 ## MSG_SKILL_LullSkill
 Lull Skill:[NL]
-Negated the effects of SKL[NL]
-boosting rally skills on the enemy.[X]
+Negates the application of
+SKL rallies in a 3 tile range.[X]
 
 ## MSG_SKILL_LullSpectrum_NAME
 Lull-Spec[X]
 
 ## MSG_SKILL_LullSpectrum
 Lull Spectrum:[NL]
-Negated the effects of any[NL]
-boosting rally skills on the enemy.[X]
+Negates the application of
+ALL rallies in a 3 tile range.[X]
 
 ## MSG_SKILL_LullSpeed_NAME
 Lull-Spd[X]
 
 ## MSG_SKILL_LullSpeed
 Lull Speed:[NL]
-Negated the effects of SPD[NL]
-boosting rally skills on the enemy.[X]
+Negates the application of
+SPD rallies in a 3 tile range.[X]
 
 ## MSG_SKILL_LullStrength_NAME
 Lull-Str[X]
 
 ## MSG_SKILL_LullStrength
 Lull Strength:[NL]
-Negated the effects of STR[NL]
-boosting rally skills on the enemy.[X]
+Negates the application of
+STR rallies in a 3 tile range.[X]
 
 ## MSG_SKILL_SteadyBrawler_NAME
 Steady-B[X]

--- a/Contants/Texts/Source/texts/Skills_Menu.txt
+++ b/Contants/Texts/Source/texts/Skills_Menu.txt
@@ -60,7 +60,8 @@ plant a mine in an area[X]
  Mine[X]
 
 ## MSG_MenuSkill_Rally_FRtext
-No allies are in range![X]
+No allies are in range,[NL]
+or Lull skill in effect.[X]
 
 ## MSG_SKILL_RallyDefense
 Rally Defense:[NL]

--- a/Wizardry/Core/SkillSys/MiscSkillEffects/MenuSkills/Rally.c
+++ b/Wizardry/Core/SkillSys/MiscSkillEffects/MenuSkills/Rally.c
@@ -7,13 +7,13 @@
 #include "constants/skills.h"
 #include "constants/texts.h"
 
-STATIC_DECLAR void AddTargetForRally(struct Unit * unit)
+STATIC_DECLAR void AddTargetForRally(struct Unit *unit)
 {
     if (UNIT_ALIVE(unit) && AreUnitsAllied(gSubjectUnit->index, unit->index))
         AddTarget(unit->xPos, unit->yPos, unit->index, 1);
 }
 
-STATIC_DECLAR void MakeTargetListForRally(struct Unit * unit)
+STATIC_DECLAR void MakeTargetListForRally(struct Unit *unit)
 {
     int x = unit->xPos;
     int y = unit->yPos;
@@ -26,7 +26,7 @@ STATIC_DECLAR void MakeTargetListForRally(struct Unit * unit)
     ForEachUnitInRange(AddTargetForRally);
 }
 
-u8 Rally_Usability(const struct MenuItemDef * def, int number)
+u8 Rally_Usability(const struct MenuItemDef *def, int number)
 {
     if (gActiveUnit->state & US_CANTOING)
         return MENU_NOTSHOWN;
@@ -34,10 +34,125 @@ u8 Rally_Usability(const struct MenuItemDef * def, int number)
     if (!HasSelectTarget(gActiveUnit, MakeTargetListForRally))
         return MENU_DISABLED;
 
+    for (int i = 0; i < ARRAY_COUNT_RANGE3x3; i++)
+    {
+        int _x = gActiveUnit->xPos + gVecs_3x3[i].x;
+        int _y = gActiveUnit->yPos + gVecs_3x3[i].y;
+
+        struct Unit *unit_enemy = GetUnitAtPosition(_x, _y);
+
+        if (!UNIT_IS_VALID(unit_enemy) || UNIT_STONED(unit_enemy) || AreUnitsAllied(gActiveUnit->index, unit_enemy->index))
+            continue;
+
+#if (defined(SID_RallyStrength) && (COMMON_SKILL_VALID(SID_RallyStrength)))
+        if (SkillTester(gActiveUnit, SID_RallyStrength))
+#if (defined(SID_LullSpectrum) && (COMMON_SKILL_VALID(SID_LullSpectrum)))
+            if (SkillTester(unit_enemy, SID_LullSpectrum))
+                return MENU_DISABLED;
+#endif
+#if (defined(SID_LullStrength) && (COMMON_SKILL_VALID(SID_LullStrength)))
+            if (SkillTester(unit_enemy, SID_LullStrength))
+                return MENU_DISABLED;
+#endif
+#endif
+
+#if (defined(SID_RallyMagic) && (COMMON_SKILL_VALID(SID_RallyMagic)))
+        if (SkillTester(gActiveUnit, SID_RallyMagic))
+#if (defined(SID_LullSpectrum) && (COMMON_SKILL_VALID(SID_LullSpectrum)))
+            if (SkillTester(unit_enemy, SID_LullSpectrum))
+                return MENU_DISABLED;
+#endif
+#if (defined(SID_LullMagic) && (COMMON_SKILL_VALID(SID_LullMagic)))
+            if (SkillTester(unit_enemy, SID_LullMagic))
+                return MENU_DISABLED;
+#endif
+#endif
+
+#if (defined(SID_RallySkill) && (COMMON_SKILL_VALID(SID_RallySkill)))
+        if (SkillTester(gActiveUnit, SID_RallySkill))
+#if (defined(SID_LullSpectrum) && (COMMON_SKILL_VALID(SID_LullSpectrum)))
+            if (SkillTester(unit_enemy, SID_LullSpectrum))
+                return MENU_DISABLED;
+#endif
+#if (defined(SID_LullSkill) && (COMMON_SKILL_VALID(SID_LullSkill)))
+            if (SkillTester(unit_enemy, SID_LullSkill))
+                return MENU_DISABLED;
+#endif
+#endif
+
+#if (defined(SID_RallySpeed) && (COMMON_SKILL_VALID(SID_RallySpeed)))
+        if (SkillTester(gActiveUnit, SID_RallySpeed))
+#if (defined(SID_LullSpectrum) && (COMMON_SKILL_VALID(SID_LullSpectrum)))
+            if (SkillTester(unit_enemy, SID_LullSpectrum))
+                return MENU_DISABLED;
+#endif
+#if (defined(SID_LullSpeed) && (COMMON_SKILL_VALID(SID_LullSpeed)))
+            if (SkillTester(unit_enemy, SID_LullSpeed))
+                return MENU_DISABLED;
+#endif
+#endif
+
+#if (defined(SID_RallyLuck) && (COMMON_SKILL_VALID(SID_RallyLuck)))
+        if (SkillTester(gActiveUnit, SID_RallyLuck))
+#if (defined(SID_LullSpectrum) && (COMMON_SKILL_VALID(SID_LullSpectrum)))
+            if (SkillTester(unit_enemy, SID_LullSpectrum))
+                return MENU_DISABLED;
+#endif
+#if (defined(SID_LullLuck) && (COMMON_SKILL_VALID(SID_LullLuck)))
+            if (SkillTester(unit_enemy, SID_LullLuck))
+                return MENU_DISABLED;
+#endif
+#endif
+
+#if (defined(SID_RallyDefense) && (COMMON_SKILL_VALID(SID_RallyDefense)))
+        if (SkillTester(gActiveUnit, SID_RallyDefense))
+#if (defined(SID_LullSpectrum) && (COMMON_SKILL_VALID(SID_LullSpectrum)))
+            if (SkillTester(unit_enemy, SID_LullSpectrum))
+                return MENU_DISABLED;
+#endif
+#if (defined(SID_LullDefense) && (COMMON_SKILL_VALID(SID_LullDefense)))
+            if (SkillTester(unit_enemy, SID_LullDefense))
+                return MENU_DISABLED;
+#endif
+#endif
+
+#if (defined(SID_RallyResistance) && (COMMON_SKILL_VALID(SID_RallyResistance)))
+        if (SkillTester(gActiveUnit, SID_RallyResistance))
+#if (defined(SID_LullSpectrum) && (COMMON_SKILL_VALID(SID_LullSpectrum)))
+            if (SkillTester(unit_enemy, SID_LullSpectrum))
+                return MENU_DISABLED;
+#endif
+#if (defined(SID_LullResistance) && (COMMON_SKILL_VALID(SID_LullResistance)))
+            if (SkillTester(unit_enemy, SID_LullResistance))
+                return MENU_DISABLED;
+#endif
+#endif
+
+#if (defined(SID_RallyMovement) && (COMMON_SKILL_VALID(SID_RallyMovement)))
+        if (SkillTester(gActiveUnit, SID_RallyMovement))
+#if (defined(SID_LullSpectrum) && (COMMON_SKILL_VALID(SID_LullSpectrum)))
+            if (SkillTester(unit_enemy, SID_LullSpectrum))
+                return MENU_DISABLED;
+#endif
+#if (defined(SID_LullMovement) && (COMMON_SKILL_VALID(SID_LullMovement)))
+            if (SkillTester(unit_enemy, SID_LullMovement))
+                return MENU_DISABLED;
+#endif
+#endif
+
+#if (defined(SID_RallySpectrum) && (COMMON_SKILL_VALID(SID_RallySpectrum)))
+        if (SkillTester(gActiveUnit, SID_RallySpectrum))
+#if (defined(SID_LullSpectrum) && (COMMON_SKILL_VALID(SID_LullSpectrum)))
+            if (SkillTester(unit_enemy, SID_LullSpectrum))
+                return MENU_DISABLED;
+#endif
+#endif
+    }
+
     return MENU_ENABLED;
 }
 
-int Rally_Hover(struct MenuProc * menu, struct MenuItemProc * item)
+int Rally_Hover(struct MenuProc *menu, struct MenuItemProc *item)
 {
     BmMapFill(gBmMapMovement, -1);
     BmMapFill(gBmMapRange, 0);
@@ -46,13 +161,13 @@ int Rally_Hover(struct MenuProc * menu, struct MenuItemProc * item)
     return 0;
 }
 
-int Rally_Unhover(struct MenuProc * menu, struct MenuItemProc * menuItem)
+int Rally_Unhover(struct MenuProc *menu, struct MenuItemProc *menuItem)
 {
     HideMoveRangeGraphics();
     return 0;
 }
 
-u8 Rally_OnSelected(struct MenuProc * menu, struct MenuItemProc * item)
+u8 Rally_OnSelected(struct MenuProc *menu, struct MenuItemProc *item)
 {
     if (item->availability == MENU_DISABLED)
     {
@@ -78,11 +193,12 @@ static void callback_exec(ProcPtr proc)
 
     for (i = 0; i < GetSelectTargetCount(); i++)
     {
-        struct Unit * unit = GetUnit(GetTarget(i)->uid);
+        struct Unit *unit = GetUnit(GetTarget(i)->uid);
         if (!UNIT_ALIVE(unit))
             continue;
 
-        switch (gActionData.unk08) {
+        switch (gActionData.unk08)
+        {
         case SID_RallyStrength:
             SetUnitStatDebuff(unit, UNIT_STAT_BUFF_RALLY_POW);
             break;

--- a/include/constants/skills-others.enum.txt
+++ b/include/constants/skills-others.enum.txt
@@ -97,16 +97,6 @@ SID_NatureRush
 SID_Expertise
 SID_PassionsFlow
 SID_LadyBlade
-// Lull skills
-// SID_LullDefense
-// SID_LullLuck
-// SID_LullMagic
-// SID_LullMovement
-// SID_LullResistance
-// SID_LullSkill
-// SID_LullSpectrum
-// SID_LullSpeed
-// SID_LullStregth
 SID_ShrewdPotential
 // SID_SteadyBrawler
 SID_KeepUp
@@ -147,6 +137,17 @@ SID_PsychUp
 SID_Moody
 SID_Amische
 SID_DownWithArch
+
+// Lull skills
+SID_LullDefense
+SID_LullLuck
+SID_LullMagic
+SID_LullMovement
+SID_LullResistance
+SID_LullSkill
+SID_LullSpectrum
+SID_LullSpeed
+SID_LullStrength
 
 // Shop skills
 SID_Deal


### PR DESCRIPTION
In an effort to avoid using EMS RAM, I opted to turn the lull skills into aura checks in a 3 tile range that will prevent the application of rallies in their range in the first place.

The code looks like shit, but it works and that's my primary focus right now.