### PR TITLE
Port-SendInventoryOnDeath

### DIFF
--- a/Data/SkillSys/SkillTable-person.c
+++ b/Data/SkillSys/SkillTable-person.c
@@ -4,7 +4,7 @@
 
 const u16 gConstSkillTable_Person[0x100][2] = {
     [CHARACTER_EIRIKA] = {
-        SID_Accost,
+        SID_Supply,
         SID_InitSpectrum,
     },
 

--- a/Wizardry/External/ExternalPatches.event
+++ b/Wizardry/External/ExternalPatches.event
@@ -13,3 +13,8 @@
 #ifdef CONFIG_INSTALL_CONVOYEXPA
     #include "ConvoyExpa/ConvoyExpa.event"
 #endif
+
+#ifdef CONFIG_INSTALL_SENDINVENTORYONDEATH
+    #include "SendInventoryOnDeath/Installer.event"
+#endif
+

--- a/Wizardry/External/SendInventoryOnDeath/Installer.event
+++ b/Wizardry/External/SendInventoryOnDeath/Installer.event
@@ -1,0 +1,11 @@
+#include "Extensions/Hack Installation.txt"
+
+PUSH
+ORG 0x18418
+jumpToHack(SendInventoryOnDeath)
+PROTECT 0x18418 currentOffset
+POP
+
+ALIGN 4
+SendInventoryOnDeath:
+#incbin "SendInventoryOnDeath.dmp"

--- a/Wizardry/External/SendInventoryOnDeath/SendInventoryOnDeath.s
+++ b/Wizardry/External/SendInventoryOnDeath/SendInventoryOnDeath.s
@@ -1,0 +1,31 @@
+.thumb
+
+.equ SendInventoryToConvoy, 0x0809A539
+
+.macro blh to, reg
+    ldr \reg, =\to
+    mov lr, \reg
+    .short 0xF800
+.endm
+
+.global SendInventoryOnDeath
+.type SendInventoryOnDeath, %function
+
+@Hooked from 8018418
+SendInventoryOnDeath:
+push   {r2}
+
+ldr    r0, [r2, #0xC]
+mov    r1, #0x5
+orr    r0, r1
+str    r0, [r2, #0xC]
+
+mov    r0, r2
+blh    SendInventoryToConvoy, r3
+
+pop    {r2}
+ldr    r3, =0x8018420|1
+bx     r3
+
+.align
+.ltorg

--- a/include/Configs/configs.h
+++ b/include/Configs/configs.h
@@ -97,6 +97,14 @@
 #define CONFIG_MAP_BATTLE_ANIM_FRAMES
 
 /**
+ * By: Contro
+ * Send a user's inventory to the supply when they die
+ * Installed in: Wizardry->External->SendInventoryOnDeath->Installer.event
+ */
+
+#define CONFIG_INSTALL_SENDINVENTORYONDEATH
+
+/**
  * Levelup mode
  * 0: vanilla
  * 1: uncontrollable


### PR DESCRIPTION
Send the user's inventory to the convoy on their death. 

Author: Contro
Source: https://github.com/masterofcontroversy/ASM/tree/main/FE8/SendInventoryOnDeath