### PR TITLE
Skill-DoubleUp

### DIFF
--- a/Contants/Texts/Source/texts/Skills_Misc.txt
+++ b/Contants/Texts/Source/texts/Skills_Misc.txt
@@ -113,3 +113,8 @@ are immune to poison.[X]
 CatchEmAll:[NL]
 Gives this unit[NL]
 every skill.[X]
+
+## MSG_SKILL_DoubleUp
+Double Up:[NL]
+Guarantees this unit gains at[NL]
+least two stats per levelup.[X]

--- a/Data/SkillSys/SkillInfo.c
+++ b/Data/SkillSys/SkillInfo.c
@@ -4086,4 +4086,12 @@ const struct SkillInfo gSkillInfos[MAX_SKILL_NUM + 1] = {
         .icon = GFX_SkillIcon_WIP,
     },
 #endif
+
+
+#if (defined(SID_DoubleUp) && COMMON_SKILL_VALID(SID_DoubleUp))
+    [SID_DoubleUp] = {
+        .desc = MSG_SKILL_DoubleUp,
+        .icon = GFX_SkillIcon_WIP,
+    },
+#endif
 };

--- a/Data/SkillSys/SkillTable-item.c
+++ b/Data/SkillSys/SkillTable-item.c
@@ -19,6 +19,7 @@ const u16 gConstSkillTable_Item[0x100][2] = {
     },
     [ITEM_ANIMA_ELFIRE] = {
         SID_TriangleAttack,
+        SID_DoubleUp,
     },
     [ITEM_LANCE_SLIM] = {
         SID_Swarm,

--- a/Wizardry/Debug/Event/Source/debug-event.c
+++ b/Wizardry/Debug/Event/Source/debug-event.c
@@ -375,7 +375,7 @@ static const struct UnitDefinition UnitDef_Enemy1[] = {
         .classIndex = CLASS_NECROMANCER,
         .autolevel = true,
         .allegiance = FACTION_ID_RED,
-        .level = 30,
+        .level = 10,
         .xPosition = 12,
         .yPosition = 24,
         .redaCount = 1,
@@ -401,6 +401,7 @@ static const EventScr EventScr_Beginning[] = {
     Evt_AddSkill(SID_Obstruct, CHARACTER_SAAR)
     Evt_AddSkill(SID_Nihil, CHARACTER_SAAR)
     Evt_AddSkill(SID_Teleportation, CHARACTER_BAZBA)
+    Evt_AddSkill(SID_DoubleUp, CHARACTER_LYON)
 
     Evt_AddSkill(SID_Aerobatics, CHARACTER_MYRRH)
     Evt_AddSkill(SID_FlierGuidance, CHARACTER_TANA)

--- a/include/constants/skills-item.enum.txt
+++ b/include/constants/skills-item.enum.txt
@@ -60,3 +60,4 @@ SID_TripUp
 SID_DemolitionExpert
 SID_Onimaru
 SID_AdaptiveLunge
+SID_DoubleUp

--- a/include/strmag.h
+++ b/include/strmag.h
@@ -4,7 +4,7 @@
 #include "status-getter.h"
 
 #define UNIT_MAG(unit) ((unit)->_u47)
-#define BU_CHG_MAG(bu) (*((u8 *)(bu) + 0x7F))
+#define BU_CHG_MAG(bu) (*((s8 *)(bu) + 0x7F))
 #define ITEM_MAG_BONUS(bonuses) *((const s8 *)bonuses + 9)
 
 struct UnitMagicInfo {


### PR DESCRIPTION
Ensure at least two stat level ups (assuming that at least two stats are unmaxed). 

Right now, this skill ignores 0% growths in stats when choosing which stats to level up. I could fix it, but it's make the skill chunkier, so I'm leaving it for now. 