### PR TITLE
Skill-Stormgift&StormgiftPlus

### DIFF
--- a/Contants/Texts/Source/texts/Skills_BattleStatus.txt
+++ b/Contants/Texts/Source/texts/Skills_BattleStatus.txt
@@ -921,22 +921,32 @@ harmful status conditions.[X]
 ## MSG_SKILL_Shadowgift
 Shadowgift:[NL]
 Grants this unit access to[NL]
-dark magic up to rank C.[X]
+Dark magic up to rank C.[X]
 
 ## MSG_SKILL_ShadowgiftPlus
 Shadowgift+:[NL]
 Grants this unit access to[NL]
-dark magic up to rank A.[X]
+Dark magic up to rank A.[X]
 
 ## MSG_SKILL_Lumina
 Lumina:[NL]
 Grants this unit access to[NL]
-light magic up to rank C.[X]
+Light magic up to rank C.[X]
 
 ## MSG_SKILL_LuminaPlus
 Lumina+:[NL]
 Grants this unit access to[NL]
-light magic up to rank A.[X]
+Light magic up to rank A.[X]
+
+## MSG_SKILL_Stormgift
+Stormgift:[NL]
+Grants this unit access to[NL]
+Anima magic up to rank C.[X]
+
+## MSG_SKILL_StormgiftPlus
+Stormgift+:[NL]
+Grants this unit access to[NL]
+Anima magic up to rank A.[X]
 
 ## MSG_SKILL_Cultured
 Cultured: If unit attacks next to a[NL]

--- a/Data/SkillSys/SkillInfo.c
+++ b/Data/SkillSys/SkillInfo.c
@@ -3888,6 +3888,20 @@ const struct SkillInfo gSkillInfos[MAX_SKILL_NUM + 1] = {
     },
 #endif
 
+#if (defined(SID_Stormgift) && COMMON_SKILL_VALID(SID_Stormgift))
+    [SID_Stormgift] = {
+        .desc = MSG_SKILL_Stormgift,
+        .icon = GFX_SkillIcon_WIP,
+    },
+#endif
+
+#if (defined(SID_StormgiftPlus) && COMMON_SKILL_VALID(SID_StormgiftPlus))
+    [SID_StormgiftPlus] = {
+        .desc = MSG_SKILL_StormgiftPlus,
+        .icon = GFX_SkillIcon_WIP,
+    },
+#endif
+
 #if (defined(SID_StealPlus) && COMMON_SKILL_VALID(SID_StealPlus))
     [SID_StealPlus] = {
         .desc = MSG_SKILL_StealPlus,

--- a/Data/SkillSys/SkillTable-person.c
+++ b/Data/SkillSys/SkillTable-person.c
@@ -4,8 +4,7 @@
 
 const u16 gConstSkillTable_Person[0x100][2] = {
     [CHARACTER_EIRIKA] = {
-        SID_Lumina,
-        SID_Shadowgift,
+        SID_StormgiftPlus,
     },
 
     [CHARACTER_EPHRAIM] = {

--- a/Wizardry/Core/BattleSys/Source/BattleHit.c
+++ b/Wizardry/Core/BattleSys/Source/BattleHit.c
@@ -250,6 +250,20 @@ void BattleGenerateHitEffects(struct BattleUnit * attacker, struct BattleUnit * 
                 gainWEXP = false;
 #endif
 
+#if (defined(SID_StormgiftPlus) && (COMMON_SKILL_VALID(SID_StormgiftPlus)))
+    if (BattleSkillTester(attacker, SID_StormgiftPlus))
+        if (GetItemType(GetUnitEquippedWeapon(GetUnit(attacker->unit.index))) == ITYPE_ANIMA)
+            if (GetUnit(attacker->unit.index)->ranks[ITYPE_ANIMA] == 0)
+                gainWEXP = false;
+#endif
+
+#if (defined(SID_Stormgift) && (COMMON_SKILL_VALID(SID_Stormgift)))
+    if (BattleSkillTester(attacker, SID_Stormgift))
+        if (GetItemType(GetUnitEquippedWeapon(GetUnit(attacker->unit.index))) == ITYPE_ANIMA)
+            if (GetUnit(attacker->unit.index)->ranks[ITYPE_ANIMA] == 0)
+                gainWEXP = false;
+#endif
+
     if (gainWEXP)
     {
 #if (defined(SID_Discipline) && (COMMON_SKILL_VALID(SID_Discipline)))

--- a/Wizardry/Core/BattleSys/Source/BattleWeapon.c
+++ b/Wizardry/Core/BattleSys/Source/BattleWeapon.c
@@ -333,6 +333,22 @@ s8 CanUnitUseWeapon(struct Unit *unit, int item)
                     return true;
 #endif
 
+#if (defined(SID_StormgiftPlus) && (COMMON_SKILL_VALID(SID_StormgiftPlus)))
+    if (SkillTester(unit, SID_StormgiftPlus))
+        if (GetItemType(item) == ITYPE_ANIMA)
+            if (unit->ranks[ITYPE_ANIMA] == 0)
+                if (GetItemRequiredExp(item) <= WPN_EXP_A) // A rank max
+                    return true;
+#endif
+
+#if (defined(SID_Stormgift) && (COMMON_SKILL_VALID(SID_Stormgift)))
+    if (SkillTester(unit, SID_Stormgift))
+        if (GetItemType(item) == ITYPE_ANIMA)
+            if (unit->ranks[ITYPE_ANIMA] == 0)
+                if (GetItemRequiredExp(item) <= WPN_EXP_C) // C rank max
+                    return true;
+#endif
+
     return (unit->ranks[GetItemType(item)] >= GetItemRequiredExp(item)) ? true : false;
 }
 

--- a/include/constants/skills-equip.enum.txt
+++ b/include/constants/skills-equip.enum.txt
@@ -575,6 +575,8 @@
 // SID_ShadowgiftPlus
 // SID_Lumina
 // SID_LuminaPlus
+// SID_Stormgift
+SID_StormgiftPlus
 // SID_NiceThighs
 // SID_Casual
 // SID_CatchEmAll  // Doesn't work

--- a/include/constants/skills-equip.enum.txt
+++ b/include/constants/skills-equip.enum.txt
@@ -576,7 +576,7 @@
 // SID_Lumina
 // SID_LuminaPlus
 // SID_Stormgift
-SID_StormgiftPlus
+// SID_StormgiftPlus
 // SID_NiceThighs
 // SID_Casual
 // SID_CatchEmAll  // Doesn't work

--- a/include/constants/skills-item.enum.txt
+++ b/include/constants/skills-item.enum.txt
@@ -575,6 +575,8 @@
 // SID_ShadowgiftPlus
 // SID_Lumina
 // SID_LuminaPlus
+// SID_Stormgift
+// SID_StormgiftPlus
 // SID_NiceThighs
 // SID_Casual
 // SID_CatchEmAll  // Doesn't work

--- a/include/constants/skills-others.enum.txt
+++ b/include/constants/skills-others.enum.txt
@@ -575,6 +575,8 @@
 // SID_ShadowgiftPlus
 // SID_Lumina
 // SID_LuminaPlus
+// SID_Stormgift
+// SID_StormgiftPlus
 // SID_NiceThighs
 // SID_Casual
 // SID_CatchEmAll  // Doesn't work


### PR DESCRIPTION
Allows the unit to use anima magic up to ranks C and A respectively.