### PR TITLE
Skill-Bladegift&BladegiftPlus

### DIFF
--- a/Contants/Texts/Source/texts/Skills_BattleStatus.txt
+++ b/Contants/Texts/Source/texts/Skills_BattleStatus.txt
@@ -958,6 +958,16 @@ Gracegift+:[NL]
 Grants this unit access to[NL]
 Staves up to rank A.[X]
 
+## MSG_SKILL_Bladegift
+Bladegift:[NL]
+Grants this unit access to[NL]
+Swords up to rank C.[X]
+
+## MSG_SKILL_BladegiftPlus
+Bladegift+:[NL]
+Grants this unit access to[NL]
+Swords up to rank A.[X]
+
 ## MSG_SKILL_Cultured
 Cultured: If unit attacks next to a[NL]
 unit with Nice Thighs, move again.[NL]

--- a/Data/SkillSys/SkillInfo.c
+++ b/Data/SkillSys/SkillInfo.c
@@ -3916,6 +3916,21 @@ const struct SkillInfo gSkillInfos[MAX_SKILL_NUM + 1] = {
     },
 #endif
 
+
+#if (defined(SID_Bladegift) && COMMON_SKILL_VALID(SID_Bladegift))
+    [SID_Bladegift] = {
+        .desc = MSG_SKILL_Bladegift,
+        .icon = GFX_SkillIcon_Bladegift,
+    },
+#endif
+
+#if (defined(SID_BladegiftPlus) && COMMON_SKILL_VALID(SID_BladegiftPlus))
+    [SID_BladegiftPlus] = {
+        .desc = MSG_SKILL_BladegiftPlus,
+        .icon = GFX_SkillIcon_WIP,
+    },
+#endif
+
 #if (defined(SID_StealPlus) && COMMON_SKILL_VALID(SID_StealPlus))
     [SID_StealPlus] = {
         .desc = MSG_SKILL_StealPlus,

--- a/Data/SkillSys/SkillTable-person.c
+++ b/Data/SkillSys/SkillTable-person.c
@@ -4,13 +4,13 @@
 
 const u16 gConstSkillTable_Person[0x100][2] = {
     [CHARACTER_EIRIKA] = {
-        SID_GracegiftPlus,
     },
 
     [CHARACTER_EPHRAIM] = {
     },
 
     [CHARACTER_SALEH] = {
+        SID_BladegiftPlus
     },
 
     [CHARACTER_VANESSA] = {

--- a/Wizardry/Core/BattleSys/Source/BattleHit.c
+++ b/Wizardry/Core/BattleSys/Source/BattleHit.c
@@ -264,6 +264,20 @@ void BattleGenerateHitEffects(struct BattleUnit * attacker, struct BattleUnit * 
                 gainWEXP = false;
 #endif
 
+#if (defined(SID_BladegiftPlus) && (COMMON_SKILL_VALID(SID_BladegiftPlus)))
+    if (BattleSkillTester(attacker, SID_BladegiftPlus))
+        if (GetItemType(GetUnitEquippedWeapon(GetUnit(attacker->unit.index))) == ITYPE_SWORD)
+            if (GetUnit(attacker->unit.index)->ranks[ITYPE_SWORD] == 0)
+                gainWEXP = false;
+#endif
+
+#if (defined(SID_Bladegift) && (COMMON_SKILL_VALID(SID_Bladegisft)))
+    if (BattleSkillTester(attacker, SID_Bladegift))
+        if (GetItemType(GetUnitEquippedWeapon(GetUnit(attacker->unit.index))) == ITYPE_SWORD)
+            if (GetUnit(attacker->unit.index)->ranks[ITYPE_SWORD] == 0)
+                gainWEXP = false;
+#endif
+
     if (gainWEXP)
     {
 #if (defined(SID_Discipline) && (COMMON_SKILL_VALID(SID_Discipline)))

--- a/Wizardry/Core/BattleSys/Source/BattleWeapon.c
+++ b/Wizardry/Core/BattleSys/Source/BattleWeapon.c
@@ -349,6 +349,22 @@ s8 CanUnitUseWeapon(struct Unit *unit, int item)
                     return true;
 #endif
 
+#if (defined(SID_BladegiftPlus) && (COMMON_SKILL_VALID(SID_BladegiftPlus)))
+    if (SkillTester(unit, SID_BladegiftPlus))
+        if (GetItemType(item) == ITYPE_SWORD)
+            if (unit->ranks[ITYPE_SWORD] == 0)
+                if (GetItemRequiredExp(item) <= WPN_EXP_A) // A rank max
+                    return true;
+#endif
+
+#if (defined(SID_Bladegift) && (COMMON_SKILL_VALID(SID_Bladegift)))
+    if (SkillTester(unit, SID_Bladegift))
+        if (GetItemType(item) == ITYPE_SWORD)
+            if (unit->ranks[ITYPE_SWORD] == 0)
+                if (GetItemRequiredExp(item) <= WPN_EXP_C) // C rank max
+                    return true;
+#endif
+
     return (unit->ranks[GetItemType(item)] >= GetItemRequiredExp(item)) ? true : false;
 }
 

--- a/include/constants/skills-equip.enum.txt
+++ b/include/constants/skills-equip.enum.txt
@@ -578,7 +578,9 @@
 // SID_Stormgift
 // SID_StormgiftPlus
 // SID_Gracegift
-SID_GracegiftPlus
+// SID_GracegiftPlus
+// SID_Bladegift
+SID_BladegiftPlus
 // SID_NiceThighs
 // SID_Casual
 // SID_CatchEmAll  // Doesn't work

--- a/include/constants/skills-item.enum.txt
+++ b/include/constants/skills-item.enum.txt
@@ -579,6 +579,8 @@
 // SID_StormgiftPlus
 // SID_Gracegift
 // SID_GracegiftPlus
+// SID_Bladegift
+// SID_BladegiftPlus
 // SID_NiceThighs
 // SID_Casual
 // SID_CatchEmAll  // Doesn't work

--- a/include/constants/skills-others.enum.txt
+++ b/include/constants/skills-others.enum.txt
@@ -579,6 +579,8 @@
 // SID_StormgiftPlus
 // SID_Gracegift
 // SID_GracegiftPlus
+// SID_Bladegift
+// SID_BladegiftPlus
 // SID_NiceThighs
 // SID_Casual
 // SID_CatchEmAll  // Doesn't work


### PR DESCRIPTION
Allows the unit to use swords up to C and A rank respectively.