### PR TITLE
Skill-AllOtherGiftSkills

### DIFF
--- a/Contants/Texts/Source/texts/Skills_BattleStatus.txt
+++ b/Contants/Texts/Source/texts/Skills_BattleStatus.txt
@@ -968,6 +968,36 @@ Bladegift+:[NL]
 Grants this unit access to[NL]
 Swords up to rank A.[X]
 
+## MSG_SKILL_Piercegift
+Piercegift:[NL]
+Grants this unit access to[NL]
+Lances up to rank C.[X]
+
+## MSG_SKILL_PiercegiftPlus
+Piercegift+:[NL]
+Grants this unit access to[NL]
+Lances up to rank A.[X]
+
+## MSG_SKILL_Hackgift
+Hackgift:[NL]
+Grants this unit access to[NL]
+Axes up to rank C.[X]
+
+## MSG_SKILL_HackgiftPlus
+Hackgift+:[NL]
+Grants this unit access to[NL]
+Axes up to rank A.[X]
+
+## MSG_SKILL_Arcgift
+Arcgift:[NL]
+Grants this unit access to[NL]
+Bows up to rank C.[X]
+
+## MSG_SKILL_ArcgiftPlus
+Arcgift+:[NL]
+Grants this unit access to[NL]
+Bows up to rank A.[X]
+
 ## MSG_SKILL_Cultured
 Cultured: If unit attacks next to a[NL]
 unit with Nice Thighs, move again.[NL]

--- a/Data/SkillSys/SkillInfo.c
+++ b/Data/SkillSys/SkillInfo.c
@@ -3916,7 +3916,6 @@ const struct SkillInfo gSkillInfos[MAX_SKILL_NUM + 1] = {
     },
 #endif
 
-
 #if (defined(SID_Bladegift) && COMMON_SKILL_VALID(SID_Bladegift))
     [SID_Bladegift] = {
         .desc = MSG_SKILL_Bladegift,
@@ -3927,6 +3926,48 @@ const struct SkillInfo gSkillInfos[MAX_SKILL_NUM + 1] = {
 #if (defined(SID_BladegiftPlus) && COMMON_SKILL_VALID(SID_BladegiftPlus))
     [SID_BladegiftPlus] = {
         .desc = MSG_SKILL_BladegiftPlus,
+        .icon = GFX_SkillIcon_WIP,
+    },
+#endif
+
+#if (defined(SID_Piercegift) && COMMON_SKILL_VALID(SID_Piercegift))
+    [SID_Piercegift] = {
+        .desc = MSG_SKILL_Piercegift,
+        .icon = GFX_SkillIcon_Piercegift,
+    },
+#endif
+
+#if (defined(SID_PiercegiftPlus) && COMMON_SKILL_VALID(SID_PiercegiftPlus))
+    [SID_PiercegiftPlus] = {
+        .desc = MSG_SKILL_PiercegiftPlus,
+        .icon = GFX_SkillIcon_WIP,
+    },
+#endif
+
+#if (defined(SID_Hackgift) && COMMON_SKILL_VALID(SID_Hackgift))
+    [SID_Hackgift] = {
+        .desc = MSG_SKILL_Hackgift,
+        .icon = GFX_SkillIcon_Hackgift,
+    },
+#endif
+
+#if (defined(SID_HackgiftPlus) && COMMON_SKILL_VALID(SID_HackgiftPlus))
+    [SID_HackgiftPlus] = {
+        .desc = MSG_SKILL_HackgiftPlus,
+        .icon = GFX_SkillIcon_WIP,
+    },
+#endif
+
+#if (defined(SID_Arcgift) && COMMON_SKILL_VALID(SID_Arcgift))
+    [SID_Arcgift] = {
+        .desc = MSG_SKILL_Arcgift,
+        .icon = GFX_SkillIcon_Arcgift,
+    },
+#endif
+
+#if (defined(SID_ArcgiftPlus) && COMMON_SKILL_VALID(SID_ArcgiftPlus))
+    [SID_ArcgiftPlus] = {
+        .desc = MSG_SKILL_ArcgiftPlus,
         .icon = GFX_SkillIcon_WIP,
     },
 #endif

--- a/Data/SkillSys/SkillTable-person.c
+++ b/Data/SkillSys/SkillTable-person.c
@@ -10,7 +10,6 @@ const u16 gConstSkillTable_Person[0x100][2] = {
     },
 
     [CHARACTER_SALEH] = {
-        SID_BladegiftPlus
     },
 
     [CHARACTER_VANESSA] = {

--- a/Wizardry/Common/UnitHooks/Source/#if (defined(SID_PiercegiftPlus) && (COM
+++ b/Wizardry/Common/UnitHooks/Source/#if (defined(SID_PiercegiftPlus) && (COM
@@ -1,0 +1,13 @@
+#if (defined(SID_PiercegiftPlus) && (COMMON_SKILL_VALID(SID_PiercegiftPlus)))
+    if (SkillTester(unit, SID_PiercegiftPlus))
+        if (GetItemType(unit->items[0]) == ITYPE_LANCE)
+            if (unit->ranks[ITYPE_LANCE] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_Piercegift) && (COMMON_SKILL_VALID(SID_Piercegift)))
+    if (SkillTester(unit, SID_Piercegift))
+        if (GetItemType(unit->items[0]) == ITYPE_LANCE)
+            if (unit->ranks[ITYPE_LANCE] == 0)
+                tmp = 0;
+#endif

--- a/Wizardry/Common/UnitHooks/Source/BattleUnitHook.c
+++ b/Wizardry/Common/UnitHooks/Source/BattleUnitHook.c
@@ -87,6 +87,48 @@ STATIC_DECLAR void UpdateUnitFromBattleVanilla(struct Unit * unit, struct Battle
 
     tmp = GetBattleUnitUpdatedWeaponExp(bu);
 
+#if (defined(SID_ShadowgiftPlus) && (COMMON_SKILL_VALID(SID_ShadowgiftPlus)))
+    if (SkillTester(unit, SID_ShadowgiftPlus))
+        if (GetItemType(unit->items[0]) == ITYPE_DARK)
+            if (unit->ranks[ITYPE_DARK] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_Shadowgift) && (COMMON_SKILL_VALID(SID_Shadowgift)))
+    if (SkillTester(unit, SID_Shadowgift))
+        if (GetItemType(unit->items[0]) == ITYPE_DARK)
+            if (unit->ranks[ITYPE_DARK] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_LuminaPlus) && (COMMON_SKILL_VALID(SID_LuminaPlus)))
+    if (SkillTester(unit, SID_LuminaPlus))
+        if (GetItemType(unit->items[0]) == ITYPE_LIGHT)
+            if (unit->ranks[ITYPE_LIGHT] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_Lumina) && (COMMON_SKILL_VALID(SID_Lumina)))
+    if (SkillTester(unit, SID_Lumina))
+        if (GetItemType(unit->items[0]) == ITYPE_LIGHT)
+            if (unit->ranks[ITYPE_LIGHT] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_StormgiftPlus) && (COMMON_SKILL_VALID(SID_StormgiftPlus)))
+    if (SkillTester(unit, SID_StormgiftPlus))
+        if (GetItemType(unit->items[0]) == ITYPE_ANIMA)
+            if (unit->ranks[ITYPE_ANIMA] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_Stormgift) && (COMMON_SKILL_VALID(SID_Stormgift)))
+    if (SkillTester(unit, SID_Stormgift))
+        if (GetItemType(unit->items[0]) == ITYPE_ANIMA)
+            if (unit->ranks[ITYPE_ANIMA] == 0)
+                tmp = 0;
+#endif
+
 #if (defined(SID_GracegiftPlus) && (COMMON_SKILL_VALID(SID_GracegiftPlus)))
     if (SkillTester(unit, SID_GracegiftPlus))
         if (GetItemType(unit->items[0]) == ITYPE_STAFF)
@@ -98,6 +140,62 @@ STATIC_DECLAR void UpdateUnitFromBattleVanilla(struct Unit * unit, struct Battle
     if (SkillTester(unit, SID_Gracegift))
         if (GetItemType(unit->items[0]) == ITYPE_STAFF)
             if (unit->ranks[ITYPE_STAFF] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_BladegiftPlus) && (COMMON_SKILL_VALID(SID_BladegiftPlus)))
+    if (SkillTester(unit, SID_BladegiftPlus))
+        if (GetItemType(unit->items[0]) == ITYPE_SWORD)
+            if (unit->ranks[ITYPE_SWORD] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_Bladegift) && (COMMON_SKILL_VALID(SID_Bladegift)))
+    if (SkillTester(unit, SID_Bladegift))
+        if (GetItemType(unit->items[0]) == ITYPE_SWORD)
+            if (unit->ranks[ITYPE_SWORD] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_PiercegiftPlus) && (COMMON_SKILL_VALID(SID_PiercegiftPlus)))
+    if (SkillTester(unit, SID_PiercegiftPlus))
+        if (GetItemType(unit->items[0]) == ITYPE_LANCE)
+            if (unit->ranks[ITYPE_LANCE] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_Piercegift) && (COMMON_SKILL_VALID(SID_Piercegift)))
+    if (SkillTester(unit, SID_Piercegift))
+        if (GetItemType(unit->items[0]) == ITYPE_LANCE)
+            if (unit->ranks[ITYPE_LANCE] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_HackgiftPlus) && (COMMON_SKILL_VALID(SID_HackgiftPlus)))
+    if (SkillTester(unit, SID_HackgiftPlus))
+        if (GetItemType(unit->items[0]) == ITYPE_AXE)
+            if (unit->ranks[ITYPE_AXE] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_Hackgift) && (COMMON_SKILL_VALID(SID_Hackgift)))
+    if (SkillTester(unit, SID_Hackgift))
+        if (GetItemType(unit->items[0]) == ITYPE_AXE)
+            if (unit->ranks[ITYPE_AXE] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_ArcgiftPlus) && (COMMON_SKILL_VALID(SID_ArcgiftPlus)))
+    if (SkillTester(unit, SID_ArcgiftPlus))
+        if (GetItemType(unit->items[0]) == ITYPE_BOW)
+            if (unit->ranks[ITYPE_BOW] == 0)
+                tmp = 0;
+#endif
+
+#if (defined(SID_Arcgift) && (COMMON_SKILL_VALID(SID_Arcgift)))
+    if (SkillTester(unit, SID_Arcgift))
+        if (GetItemType(unit->items[0]) == ITYPE_BOW)
+            if (unit->ranks[ITYPE_BOW] == 0)
                 tmp = 0;
 #endif
 

--- a/Wizardry/Core/BattleSys/Source/BattleHit.c
+++ b/Wizardry/Core/BattleSys/Source/BattleHit.c
@@ -278,6 +278,48 @@ void BattleGenerateHitEffects(struct BattleUnit * attacker, struct BattleUnit * 
                 gainWEXP = false;
 #endif
 
+#if (defined(SID_PiercegiftPlus) && (COMMON_SKILL_VALID(SID_PiercegiftPlus)))
+    if (BattleSkillTester(attacker, SID_PiercegiftPlus))
+        if (GetItemType(GetUnitEquippedWeapon(GetUnit(attacker->unit.index))) == ITYPE_LANCE)
+            if (GetUnit(attacker->unit.index)->ranks[ITYPE_LANCE] == 0)
+                gainWEXP = false;
+#endif
+
+#if (defined(SID_Piercegift) && (COMMON_SKILL_VALID(SID_Piercegisft)))
+    if (BattleSkillTester(attacker, SID_Piercegift))
+        if (GetItemType(GetUnitEquippedWeapon(GetUnit(attacker->unit.index))) == ITYPE_LANCE)
+            if (GetUnit(attacker->unit.index)->ranks[ITYPE_LANCE] == 0)
+                gainWEXP = false;
+#endif
+
+#if (defined(SID_HackgiftPlus) && (COMMON_SKILL_VALID(SID_HackgiftPlus)))
+    if (BattleSkillTester(attacker, SID_HackgiftPlus))
+        if (GetItemType(GetUnitEquippedWeapon(GetUnit(attacker->unit.index))) == ITYPE_AXE)
+            if (GetUnit(attacker->unit.index)->ranks[ITYPE_AXE] == 0)
+                gainWEXP = false;
+#endif
+
+#if (defined(SID_Hackgift) && (COMMON_SKILL_VALID(SID_Hackgisft)))
+    if (BattleSkillTester(attacker, SID_Hackgift))
+        if (GetItemType(GetUnitEquippedWeapon(GetUnit(attacker->unit.index))) == ITYPE_AXE)
+            if (GetUnit(attacker->unit.index)->ranks[ITYPE_AXE] == 0)
+                gainWEXP = false;
+#endif
+
+#if (defined(SID_ArcgiftPlus) && (COMMON_SKILL_VALID(SID_ArcgiftPlus)))
+    if (BattleSkillTester(attacker, SID_ArcgiftPlus))
+        if (GetItemType(GetUnitEquippedWeapon(GetUnit(attacker->unit.index))) == ITYPE_BOW)
+            if (GetUnit(attacker->unit.index)->ranks[ITYPE_BOW] == 0)
+                gainWEXP = false;
+#endif
+
+#if (defined(SID_Arcgift) && (COMMON_SKILL_VALID(SID_Arcgift)))
+    if (BattleSkillTester(attacker, SID_Arcgift))
+        if (GetItemType(GetUnitEquippedWeapon(GetUnit(attacker->unit.index))) == ITYPE_BOW)
+            if (GetUnit(attacker->unit.index)->ranks[ITYPE_BOW] == 0)
+                gainWEXP = false;
+#endif
+
     if (gainWEXP)
     {
 #if (defined(SID_Discipline) && (COMMON_SKILL_VALID(SID_Discipline)))

--- a/Wizardry/Core/BattleSys/Source/BattleWeapon.c
+++ b/Wizardry/Core/BattleSys/Source/BattleWeapon.c
@@ -365,6 +365,54 @@ s8 CanUnitUseWeapon(struct Unit *unit, int item)
                     return true;
 #endif
 
+#if (defined(SID_PiercegiftPlus) && (COMMON_SKILL_VALID(SID_PiercegiftPlus)))
+    if (SkillTester(unit, SID_PiercegiftPlus))
+        if (GetItemType(item) == ITYPE_LANCE)
+            if (unit->ranks[ITYPE_LANCE] == 0)
+                if (GetItemRequiredExp(item) <= WPN_EXP_A) // A rank max
+                    return true;
+#endif
+
+#if (defined(SID_Piercegift) && (COMMON_SKILL_VALID(SID_Piercegift)))
+    if (SkillTester(unit, SID_Piercegift))
+        if (GetItemType(item) == ITYPE_LANCE)
+            if (unit->ranks[ITYPE_LANCE] == 0)
+                if (GetItemRequiredExp(item) <= WPN_EXP_C) // C rank max
+                    return true;
+#endif
+
+#if (defined(SID_HackgiftPlus) && (COMMON_SKILL_VALID(SID_HackgiftPlus)))
+    if (SkillTester(unit, SID_HackgiftPlus))
+        if (GetItemType(item) == ITYPE_AXE)
+            if (unit->ranks[ITYPE_AXE] == 0)
+                if (GetItemRequiredExp(item) <= WPN_EXP_A) // A rank max
+                    return true;
+#endif
+
+#if (defined(SID_Hackgift) && (COMMON_SKILL_VALID(SID_Hackgift)))
+    if (SkillTester(unit, SID_Hackgift))
+        if (GetItemType(item) == ITYPE_AXE)
+            if (unit->ranks[ITYPE_AXE] == 0)
+                if (GetItemRequiredExp(item) <= WPN_EXP_C) // C rank max
+                    return true;
+#endif
+
+#if (defined(SID_ArcgiftPlus) && (COMMON_SKILL_VALID(SID_ArcgiftPlus)))
+    if (SkillTester(unit, SID_ArcgiftPlus))
+        if (GetItemType(item) == ITYPE_BOW)
+            if (unit->ranks[ITYPE_BOW] == 0)
+                if (GetItemRequiredExp(item) <= WPN_EXP_A) // A rank max
+                    return true;
+#endif
+
+#if (defined(SID_Arcgift) && (COMMON_SKILL_VALID(SID_Arcgift)))
+    if (SkillTester(unit, SID_Arcgift))
+        if (GetItemType(item) == ITYPE_BOW)
+            if (unit->ranks[ITYPE_BOW] == 0)
+                if (GetItemRequiredExp(item) <= WPN_EXP_C) // C rank max
+                    return true;
+#endif
+
     return (unit->ranks[GetItemType(item)] >= GetItemRequiredExp(item)) ? true : false;
 }
 

--- a/Wizardry/Core/SkillSys/MiscSkillEffects/Misc/MiscFunctions.c
+++ b/Wizardry/Core/SkillSys/MiscSkillEffects/Misc/MiscFunctions.c
@@ -465,6 +465,48 @@ void BeginUnitPoisonDamageAnim(struct Unit * unit, int damage)
 LYN_REPLACE_CHECK(HasBattleUnitGainedWeaponLevel);
 s8 HasBattleUnitGainedWeaponLevel(struct BattleUnit* bu) {
 
+#if (defined(SID_ShadowgiftPlus) && (COMMON_SKILL_VALID(SID_ShadowgiftPlus)))
+    if (BattleSkillTester(bu, SID_ShadowgiftPlus))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_DARK)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_DARK] == 0)
+                return false;
+#endif
+
+#if (defined(SID_Shadowgift) && (COMMON_SKILL_VALID(SID_Shadowgift)))
+    if (BattleSkillTester(bu, SID_SHadowgift))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_DARK)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_DARK] == 0)
+                return false;
+#endif
+
+#if (defined(SID_LuminaPlus) && (COMMON_SKILL_VALID(SID_LuminaPlus)))
+    if (BattleSkillTester(bu, SID_LuminaPlus))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_LIGHT)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_LIGHT] == 0)
+                return false;
+#endif
+
+#if (defined(SID_StormgiftPlus) && (COMMON_SKILL_VALID(SID_StormgiftPlus)))
+    if (BattleSkillTester(bu, SID_StormgiftPlus))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_ANIMA)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_ANIMA] == 0)
+                return false;
+#endif
+
+#if (defined(SID_Stormgift) && (COMMON_SKILL_VALID(SID_Stormgift)))
+    if (BattleSkillTester(bu, SID_Stormgift))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_ANIMA)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_ANIMA] == 0)
+                return false;
+#endif
+
+#if (defined(SID_Gracegift) && (COMMON_SKILL_VALID(SID_Gracegift)))
+    if (BattleSkillTester(bu, SID_Gracegift))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_STAFF)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_STAFF] == 0)
+                return false;
+#endif
+
 #if (defined(SID_GracegiftPlus) && (COMMON_SKILL_VALID(SID_GracegiftPlus)))
     if (BattleSkillTester(bu, SID_GracegiftPlus))
         if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_STAFF)
@@ -476,6 +518,62 @@ s8 HasBattleUnitGainedWeaponLevel(struct BattleUnit* bu) {
     if (BattleSkillTester(bu, SID_Gracegift))
         if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_STAFF)
             if (GetUnit(bu->unit.index)->ranks[ITYPE_STAFF] == 0)
+                return false;
+#endif
+
+#if (defined(SID_BladegiftPlus) && (COMMON_SKILL_VALID(SID_BladegiftPlus)))
+    if (BattleSkillTester(bu, SID_BladegiftPlus))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_SWORD)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_SWORD] == 0)
+                return false;
+#endif
+
+#if (defined(SID_Bladegift) && (COMMON_SKILL_VALID(SID_Bladegift)))
+    if (BattleSkillTester(bu, SID_Bladegift))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_SWORD)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_SWORD] == 0)
+                return false;
+#endif
+
+#if (defined(SID_PiercegiftPlus) && (COMMON_SKILL_VALID(SID_PiercegiftPlus)))
+    if (BattleSkillTester(bu, SID_PiercegiftPlus))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_LANCE)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_LANCE] == 0)
+                return false;
+#endif
+
+#if (defined(SID_Piercegift) && (COMMON_SKILL_VALID(SID_Piercegift)))
+    if (BattleSkillTester(bu, SID_Piercegift))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_LANCE)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_LANCE] == 0)
+                return false;
+#endif
+
+#if (defined(SID_HackgiftPlus) && (COMMON_SKILL_VALID(SID_HackgiftPlus)))
+    if (BattleSkillTester(bu, SID_HackgiftPlus))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_AXE)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_AXE] == 0)
+                return false;
+#endif
+
+#if (defined(SID_Hackgift) && (COMMON_SKILL_VALID(SID_Hackgift)))
+    if (BattleSkillTester(bu, SID_Hackgift))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_AXE)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_AXE] == 0)
+                return false;
+#endif
+
+#if (defined(SID_ArcgiftPlus) && (COMMON_SKILL_VALID(SID_ArcgiftPlus)))
+    if (BattleSkillTester(bu, SID_ArcgiftPlus))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_BOW)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_BOW] == 0)
+                return false;
+#endif
+
+#if (defined(SID_Arcgift) && (COMMON_SKILL_VALID(SID_Arcgift)))
+    if (BattleSkillTester(bu, SID_Arcgift))
+        if (GetItemType(GetUnit(bu->unit.index)->items[0]) == ITYPE_BOW)
+            if (GetUnit(bu->unit.index)->ranks[ITYPE_BOW] == 0)
                 return false;
 #endif
 

--- a/include/constants/skills-equip.enum.txt
+++ b/include/constants/skills-equip.enum.txt
@@ -580,7 +580,13 @@
 // SID_Gracegift
 // SID_GracegiftPlus
 // SID_Bladegift
-SID_BladegiftPlus
+// SID_BladegiftPlus
+// SID_Piercegift
+// SID_PiercegiftPlus
+// SID_Hackgift
+// SID_HackgiftPlus
+// SID_Arcgift
+// SID_ArcgiftPlus
 // SID_NiceThighs
 // SID_Casual
 // SID_CatchEmAll  // Doesn't work

--- a/include/constants/skills-item.enum.txt
+++ b/include/constants/skills-item.enum.txt
@@ -581,6 +581,12 @@
 // SID_GracegiftPlus
 // SID_Bladegift
 // SID_BladegiftPlus
+// SID_Piercegift
+// SID_PiercegiftPlus
+// SID_Hackgift
+// SID_HackgiftPlus
+// SID_Arcgift
+// SID_ArcgiftPlus
 // SID_NiceThighs
 // SID_Casual
 // SID_CatchEmAll  // Doesn't work

--- a/include/constants/skills-others.enum.txt
+++ b/include/constants/skills-others.enum.txt
@@ -581,6 +581,12 @@
 // SID_GracegiftPlus
 // SID_Bladegift
 // SID_BladegiftPlus
+// SID_Piercegift
+// SID_PiercegiftPlus
+// SID_Hackgift
+// SID_HackgiftPlus
+// SID_Arcgift
+// SID_ArcgiftPlus
 // SID_NiceThighs
 // SID_Casual
 // SID_CatchEmAll  // Doesn't work


### PR DESCRIPTION
All remaining gift skills that allow units to use weapon types for the respective skills up to ranks C and A.

It seems I have to add 4 hook points for each of these skills

1) To block the multiplier
2) To block the wexp gain on kill
3) To block the popup
4) To check if the unit can use the weapon. 

I might see what I can do about adding a global flag for the skill for the turn/phase.