### PR TITLE
Skill-Survivor

### DIFF
--- a/Contants/Texts/Source/texts/Skills_Misc.txt
+++ b/Contants/Texts/Source/texts/Skills_Misc.txt
@@ -164,3 +164,8 @@ bets and wins.[X]
 Poison Heal:[NL]
 Unit instead heals whatever[NL]
 damage taken when poisoned.[X]
+
+## MSG_SKILL_Survivor
+Survivor:[NL]
+Boost max HP by +1 at[NL]
+the end of the chapter.[X]

--- a/Data/SkillSys/SkillInfo.c
+++ b/Data/SkillSys/SkillInfo.c
@@ -4326,4 +4326,11 @@ const struct SkillInfo gSkillInfos[MAX_SKILL_NUM + 1] = {
         .icon = GFX_SkillIcon_WIP,
     },
 #endif
+
+#if (defined(SID_Survivor) && COMMON_SKILL_VALID(SID_Survivor))
+    [SID_Survivor] = {
+        .desc = MSG_SKILL_Survivor,
+        .icon = GFX_SkillIcon_WIP,
+    },
+#endif
 };

--- a/Data/SkillSys/SkillTable-person.c
+++ b/Data/SkillSys/SkillTable-person.c
@@ -4,6 +4,7 @@
 
 const u16 gConstSkillTable_Person[0x100][2] = {
     [CHARACTER_EIRIKA] = {
+        SID_Survivor
     },
 
     [CHARACTER_EPHRAIM] = {

--- a/Wizardry/Core/SkillSys/MiscSkillEffects/MapSkills/MapSkills.c
+++ b/Wizardry/Core/SkillSys/MiscSkillEffects/MapSkills/MapSkills.c
@@ -299,6 +299,12 @@ void ChapterChangeUnitCleanup(void)
         }
 #endif
 
+// Boost HP of unit by 1
+#if defined(SID_Survivor) && (COMMON_SKILL_VALID(SID_Survivor))
+        if (SkillTester(unit, SID_Survivor))
+            unit->maxHP += 1;
+#endif
+
         if (unit && unit->pCharacterData)
         {
             SetUnitHp(unit, GetUnitMaxHp(unit));

--- a/include/constants/skills-equip.enum.txt
+++ b/include/constants/skills-equip.enum.txt
@@ -598,6 +598,7 @@
 // SID_MagicSeal
 // SID_HazeHunter
 // SID_Insomnia
+SID_Survivor
 
 ///////// COMBAT ARTS
 // SID_COMBAT_Grounder

--- a/include/constants/skills-item.enum.txt
+++ b/include/constants/skills-item.enum.txt
@@ -598,6 +598,7 @@
 // SID_MagicSeal
 // SID_HazeHunter
 // SID_Insomnia
+// SID_Survivor
 
 ///////// COMBAT ARTS
 // SID_COMBAT_Grounder

--- a/include/constants/skills-others.enum.txt
+++ b/include/constants/skills-others.enum.txt
@@ -598,6 +598,7 @@
 // SID_MagicSeal
 // SID_HazeHunter
 // SID_Insomnia
+// SID_Survivor
 
 ///////// COMBAT ARTS
 // SID_COMBAT_Grounder


### PR DESCRIPTION
Boost the user's max HP by +1 at the end of a chapter. 

It seems if you have interludes between chapters (like going to King Hayden's castle at the end of chapter 1) the function this skill hooks into `ChapterChangeUnitCleanup` is called again, so you can end up with 2 or more addition HP per chapter.

I might look into fixing it if it becomes a problem.