### PR TITLE
Skill-Entrepreneur

### DIFF
--- a/Contants/Texts/Source/texts/Skills_Menu.txt
+++ b/Contants/Texts/Source/texts/Skills_Menu.txt
@@ -382,3 +382,14 @@ dismount, and revert.[X]
 
 ## MSG_MenuSkill_DismountName
  Dismount[X]
+
+## MSG_MenuSkill_EntrepreneurName
+ Entrepreneur[X]
+
+## MSG_SKILL_Entrepreneur
+Entrepreneur:[NL]
+Unit moves with the preparation[NL]
+shop attached to them.[X]
+
+## MSG_MenuSkill_Entrepreneur_FRtext
+No allies are in range![X]

--- a/Data/SkillSys/SkillActionInfo.c
+++ b/Data/SkillSys/SkillActionInfo.c
@@ -122,4 +122,8 @@ const SkillActionFunc_t gSkillActionFuncTable[MAX_SKILL_NUM + 1] = {
 #if (defined(SID_Dismount) && COMMON_SKILL_VALID(SID_Dismount))
     [SID_Dismount] = Action_Dismount,
 #endif
+
+#if (defined(SID_Entrepreneur) && COMMON_SKILL_VALID(SID_Entrepreneur))
+    [SID_Entrepreneur] = Action_Entrepreneur,
+#endif
 };

--- a/Data/SkillSys/SkillInfo.c
+++ b/Data/SkillSys/SkillInfo.c
@@ -4354,4 +4354,11 @@ const struct SkillInfo gSkillInfos[MAX_SKILL_NUM + 1] = {
         .icon = GFX_SkillIcon_WIP,
     },
 #endif
+
+#if (defined(SID_Entrepreneur) && COMMON_SKILL_VALID(SID_Entrepreneur))
+    [SID_Entrepreneur] = {
+        .desc = MSG_SKILL_Entrepreneur,
+        .icon = GFX_SkillIcon_WIP,
+    },
+#endif
 };

--- a/Data/SkillSys/SkillMenuInfo.c
+++ b/Data/SkillSys/SkillMenuInfo.c
@@ -528,4 +528,19 @@ const struct MenuItemDef gSkillMenuInfos[MAX_SKILL_NUM + 1] = {
         .onSwitchOut = NULL,
     },
 #endif
+
+#if (defined(SID_Entrepreneur) && COMMON_SKILL_VALID(SID_Entrepreneur))
+    [SID_Entrepreneur] = {
+        .name = "　",
+        .nameMsgId = MSG_MenuSkill_EntrepreneurName,
+        .helpMsgId = MSG_SKILL_Entrepreneur,
+        .color = TEXT_COLOR_SYSTEM_WHITE,
+        .isAvailable = Entrepreneur_Usability,
+        .onDraw = NULL,
+        .onSelected = Entrepreneur_OnSelected,
+        .onIdle = NULL,
+        .onSwitchIn = NULL,
+        .onSwitchOut = NULL,
+    },
+#endif
 };

--- a/Data/SkillSys/SkillTable-person.c
+++ b/Data/SkillSys/SkillTable-person.c
@@ -4,6 +4,7 @@
 
 const u16 gConstSkillTable_Person[0x100][2] = {
     [CHARACTER_EIRIKA] = {
+        SID_Entrepreneur
     },
 
     [CHARACTER_EPHRAIM] = {

--- a/Wizardry/Core/SkillSys/MiscSkillEffects/MenuSkills/Entrepreneur.c
+++ b/Wizardry/Core/SkillSys/MiscSkillEffects/MenuSkills/Entrepreneur.c
@@ -1,0 +1,71 @@
+#include "common-chax.h"
+#include "kernel-lib.h"
+#include "map-anims.h"
+#include "skill-system.h"
+#include "event-rework.h"
+#include "constants/skills.h"
+#include "constants/texts.h"
+#include "unit-expa.h"
+#include "action-expa.h"
+
+#if defined(SID_Entrepreneur) && (COMMON_SKILL_VALID(SID_Entrepreneur))
+
+u16 CONST_DATA gDefaultShopInventory[] = {
+    ITEM_SWORD_IRON, ITEM_LANCE_IRON, ITEM_AXE_IRON, ITEM_BOW_IRON, ITEM_ANIMA_FIRE, ITEM_STAFF_HEAL, ITEM_NONE,
+};
+
+u8 Entrepreneur_Usability(const struct MenuItemDef * def, int number)
+{
+    if (gActiveUnit->state & US_CANTOING)
+        return MENU_NOTSHOWN;
+
+    if (UNIT_CLASS_ID(gActiveUnit) == CLASS_PHANTOM)
+        return MENU_NOTSHOWN;
+
+    if (SkillTester(gActiveUnit, SID_Entrepreneur))
+        return MENU_ENABLED;
+
+    for (int i = 0; i < ARRAY_COUNT_RANGE1x1; i++)
+    {
+        struct Unit * unit = GetUnitAtPosition(gActiveUnit->xPos + gVecs_1x1[i].x, gActiveUnit->yPos + gVecs_1x1[i].y);
+
+        if (!UNIT_IS_VALID(unit) || !AreUnitsAllied(gActiveUnit->index, unit->index))
+            continue;
+
+        if (SkillTester(unit, SID_Entrepreneur))
+            return MENU_ENABLED;
+    }
+
+    return MENU_NOTSHOWN;
+}
+
+u8 Entrepreneur_OnSelected(struct MenuProc * menu, struct MenuItemProc * item)
+{
+    if (item->availability == MENU_DISABLED)
+    {
+        MenuFrozenHelpBox(menu, MSG_MenuSkill_Entrepreneur_FRtext);
+        return MENU_ACT_SND6B;
+    }
+
+    gActionData.unk08 = SID_Entrepreneur;
+    gActionData.unitActionType = CONFIG_UNIT_ACTION_EXPA_ExecSkill;
+
+    return MENU_ACT_SKIPCURSOR | MENU_ACT_END | MENU_ACT_SND6A | MENU_ACT_CLEAR;
+}
+
+static void callback_anim(ProcPtr proc)
+{
+    // Nothing happens here for now
+}
+
+static void callback_exec(ProcPtr proc)
+{
+    StartShopScreen(gActiveUnit, NULL, SHOP_TYPE_ARMORY, proc);
+}
+
+bool Action_Entrepreneur(ProcPtr parent)
+{
+    NewMuSkillAnimOnActiveUnit(gActionData.unk08, callback_anim, callback_exec);
+    return true;
+}
+#endif

--- a/Wizardry/Core/SkillSys/MiscSkillEffects/MiscSkillEffects.event
+++ b/Wizardry/Core/SkillSys/MiscSkillEffects/MiscSkillEffects.event
@@ -44,6 +44,7 @@
 #include "MenuSkills/Capture.lyn.event"
 #include "MenuSkills/Doppleganger.lyn.event"
 #include "MenuSkills/Dismount.lyn.event"
+#include "MenuSkills/Entrepreneur.lyn.event"
 
 #include "MenuSkills/ReciprocalAid.lyn.event"
 #include "MenuSkills/ReciprocalAid_ASM_Extras/Installer.event"

--- a/include/constants/skills-equip.enum.txt
+++ b/include/constants/skills-equip.enum.txt
@@ -37,6 +37,7 @@
 // SID_Reposition
 // SID_Shove
 // SID_Smite
+SID_Entrepreneur
 
 ////////// PRE-BATTLE SKILLS 
 // SID_DefiantStr
@@ -533,7 +534,6 @@
 // SID_LimitBreakerPlus
 // SID_DarkHorse
 // SID_Mercurious
-// SID_Absolve
 
 ////////// LEGENDARY SKILLS
 // SID_LEGEND_InoriAtk
@@ -601,7 +601,8 @@
 // SID_HazeHunter
 // SID_Insomnia
 // SID_Survivor
-SID_Anchor
+// SID_Anchor
+// SID_Absolve
 
 ///////// COMBAT ARTS
 // SID_COMBAT_Grounder

--- a/include/constants/skills-item.enum.txt
+++ b/include/constants/skills-item.enum.txt
@@ -37,6 +37,7 @@
 // SID_Reposition
 // SID_Shove
 // SID_Smite
+// SID_Entrepreneur
 
 ////////// PRE-BATTLE SKILLS 
 // SID_DefiantStr
@@ -533,7 +534,6 @@
 // SID_LimitBreakerPlus
 // SID_DarkHorse
 // SID_Mercurious
-// SID_Absolve
 
 ////////// LEGENDARY SKILLS
 // SID_LEGEND_InoriAtk
@@ -602,6 +602,7 @@
 // SID_Insomnia
 // SID_Survivor
 // SID_Anchor
+// SID_Absolve
 
 ///////// COMBAT ARTS
 // SID_COMBAT_Grounder

--- a/include/constants/skills-others.enum.txt
+++ b/include/constants/skills-others.enum.txt
@@ -37,6 +37,7 @@
 // SID_Reposition
 // SID_Shove
 // SID_Smite
+// SID_Entrepreneur
 
 ////////// PRE-BATTLE SKILLS 
 // SID_DefiantStr

--- a/include/skill-system.h
+++ b/include/skill-system.h
@@ -324,6 +324,8 @@ u8 Doppleganger_Usability(const struct MenuItemDef * def, int number);
 u8 Doppleganger_OnSelected(struct MenuProc * menu, struct MenuItemProc * item);
 u8 Dismount_Usability(const struct MenuItemDef * def, int number);
 u8 Dismount_OnSelected(struct MenuProc * menu, struct MenuItemProc * item);
+u8 Entrepreneur_Usability(const struct MenuItemDef * def, int number);
+u8 Entrepreneur_OnSelected(struct MenuProc * menu, struct MenuItemProc * item);
 
 /* Skill actions */
 bool Action_HealingFocus(ProcPtr proc);
@@ -349,3 +351,4 @@ bool Action_Sacrifice(ProcPtr parent);
 bool Action_Capture(ProcPtr parent);
 bool Action_Doppleganger(ProcPtr parent);
 bool Action_Dismount(ProcPtr parent);
+bool Action_Entrepreneur(ProcPtr parent);


### PR DESCRIPTION
Allows the unit to carry around a shop with them. 

Currently only works for the skill holder, but the plan is to make it work for all allied adjacent units.