### PR TITLE
Skill-Mantle

### DIFF
--- a/Contants/Texts/Source/texts/Skills_BattleStatus.txt
+++ b/Contants/Texts/Source/texts/Skills_BattleStatus.txt
@@ -1079,3 +1079,8 @@ stat it targets each turn.[X]
 Fluffy:[NL]
 Halve damage taken by melee[NL]
 attacks, double damage at range.[X]
+
+## MSG_SKILL_Mantle
+Mantle:[NL]
+Cannot taken damage except[NL]
+from selected weaponry.[X]

--- a/Data/SkillSys/SkillInfo.c
+++ b/Data/SkillSys/SkillInfo.c
@@ -4396,4 +4396,11 @@ const struct SkillInfo gSkillInfos[MAX_SKILL_NUM + 1] = {
         .icon = GFX_SkillIcon_WIP,
     },
 #endif
+
+#if (defined(SID_Mantle) && COMMON_SKILL_VALID(SID_Mantle))
+    [SID_Mantle] = {
+        .desc = MSG_SKILL_Mantle,
+        .icon = GFX_SkillIcon_WIP,
+    },
+#endif
 };

--- a/Wizardry/Core/BattleSys/Source/BattleCalcReal.c
+++ b/Wizardry/Core/BattleSys/Source/BattleCalcReal.c
@@ -165,6 +165,15 @@ STATIC_DECLAR void BattleCalcReal_ComputSkills(struct BattleUnit * attacker, str
     }
 #endif
 
+#if (defined(SID_Mantle) && (COMMON_SKILL_VALID(SID_Mantle)))
+    if (BattleSkillTester(defender, SID_Mantle))
+    {
+        NoCashGBAPrintf("Weapon ID is: %d", GetUnitEquippedWeapon(GetUnit(attacker->unit.index)));
+        if (GetItemIndex(attacker->weapon) != ITEM_AXE_IRON)
+            attacker->battleAttack = 0;
+    }
+#endif
+
 #if (defined(SID_NoGuard) && (COMMON_SKILL_VALID(SID_NoGuard)))
     if (BattleSkillTester(attacker, SID_NoGuard) || BattleSkillTester(defender, SID_NoGuard))
         attacker->battleEffectiveHitRate = 100;

--- a/Wizardry/Core/BattleSys/Source/BattleCalcReal.c
+++ b/Wizardry/Core/BattleSys/Source/BattleCalcReal.c
@@ -168,7 +168,6 @@ STATIC_DECLAR void BattleCalcReal_ComputSkills(struct BattleUnit * attacker, str
 #if (defined(SID_Mantle) && (COMMON_SKILL_VALID(SID_Mantle)))
     if (BattleSkillTester(defender, SID_Mantle))
     {
-        NoCashGBAPrintf("Weapon ID is: %d", GetUnitEquippedWeapon(GetUnit(attacker->unit.index)));
         if (GetItemIndex(attacker->weapon) != ITEM_AXE_IRON)
             attacker->battleAttack = 0;
     }

--- a/include/constants/skills-equip.enum.txt
+++ b/include/constants/skills-equip.enum.txt
@@ -201,7 +201,7 @@ SID_Entrepreneur
 // SID_ShortShield
 // SID_AvoidSword
 // SID_Adaptable
-SID_Mantle
+// SID_Mantle
 
 ////////// POST-BATTLE SKILLS
 // SID_Canto

--- a/include/constants/skills-equip.enum.txt
+++ b/include/constants/skills-equip.enum.txt
@@ -201,6 +201,7 @@ SID_Entrepreneur
 // SID_ShortShield
 // SID_AvoidSword
 // SID_Adaptable
+SID_Mantle
 
 ////////// POST-BATTLE SKILLS
 // SID_Canto

--- a/include/constants/skills-item.enum.txt
+++ b/include/constants/skills-item.enum.txt
@@ -200,6 +200,7 @@
 // SID_Vanity
 // SID_ShortShield
 // SID_AvoidSword
+// SID_Mantle
 
 ////////// POST-BATTLE SKILLS
 // SID_Canto

--- a/include/constants/skills-others.enum.txt
+++ b/include/constants/skills-others.enum.txt
@@ -200,6 +200,7 @@
 // SID_Vanity
 // SID_ShortShield
 // SID_AvoidSword
+// SID_Mantle
 
 ////////// POST-BATTLE SKILLS
 // SID_Canto


### PR DESCRIPTION
Skill holder takes no damage from weapons that aren't in a specified list (currently set to just allow an Iron Axe).